### PR TITLE
Add Stripe donation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Donations
+
+You can accept donations through Stripe by setting up the following environment variables:
+
+```
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PRICE_ID=price_...
+STRIPE_SUCCESS_URL=http://localhost:3000/donate
+STRIPE_CANCEL_URL=http://localhost:3000/donate
+```
+
+After configuring these variables, run the development server and visit `/donate` to test the checkout flow.

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
+        "stripe": "^14.0.0",
       },
       "devDependencies": {
         "@types/node": "^22.15.18",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1"
+    ,
+    "stripe": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.18",

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from "next/server";
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+  apiVersion: "2023-10-16"
+});
+
+export async function POST(req: NextRequest) {
+  const session = await stripe.checkout.sessions.create({
+    line_items: [
+      {
+        price: process.env.STRIPE_PRICE_ID || "",
+        quantity: 1
+      }
+    ],
+    mode: "payment",
+    success_url: process.env.STRIPE_SUCCESS_URL || "",
+    cancel_url: process.env.STRIPE_CANCEL_URL || ""
+  });
+
+  return new Response(JSON.stringify({ url: session.url }), {
+    headers: { "Content-Type": "application/json" }
+  });
+}

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useState } from 'react'
+
+export default function DonatePage() {
+  const [loading, setLoading] = useState(false)
+
+  const handleDonate = async () => {
+    setLoading(true)
+    const res = await fetch('/api/create-checkout-session', { method: 'POST' })
+    if (res.ok) {
+      const data = await res.json()
+      window.location.href = data.url
+    } else {
+      alert('Failed to start checkout')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
+      <h1 className="text-2xl font-bold">Support This Project</h1>
+      <button
+        onClick={handleDonate}
+        disabled={loading}
+        className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+      >
+        {loading ? 'Redirecting…' : 'Donate with Stripe'}
+      </button>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,12 @@ export default function Home() {
           >
             Read our docs
           </a>
+          <a
+            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
+            href="/donate"
+          >
+            Donate
+          </a>
         </div>
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">


### PR DESCRIPTION
## Summary
- create API route to create Stripe checkout session
- add new `/donate` page with a button to start checkout
- link to donation page from the homepage
- document required Stripe environment variables
- note Stripe dependency in package.json

## Testing
- `npm run lint` *(fails: `next` not found)*